### PR TITLE
Update core drupal

### DIFF
--- a/tools/build.make.tpl
+++ b/tools/build.make.tpl
@@ -1,7 +1,7 @@
 core = 7.x
 api = 2
 
-projects[drupal][version] = "7.15"
+projects[drupal][version] = "7.22"
 
 projects[***MACHINE_NAME***][type] = "profile"
 projects[***MACHINE_NAME***][download][type] = "kraftwagen_directory"


### PR DESCRIPTION
Drupal 7.22 was released this week, we were lagging at 7.15. Since latest security fix came out in 7.20, I think we should keep an eye on it.
