### PR TITLE
Update Panopoly Skeleton to 1.2

### DIFF
--- a/SKELETON.info
+++ b/SKELETON.info
@@ -1,5 +1,7 @@
 name = ***HUMAN_NAME***
 description = Install site for ***HUMAN_NAME***
+distribution_name = ***HUMAN_NAME***
+exclusive = 1
 core = 7.x
 
 files[] = ***MACHINE_NAME***.profile
@@ -39,15 +41,19 @@ dependencies[] = panopoly_wysiwyg
 
 ; Panopoly Recommended - Admin
 dependencies[] = navbar
+dependencies[] = breakpoints
 dependencies[] = backports
 dependencies[] = simplified_menu_admin
 dependencies[] = save_draft
 dependencies[] = module_filter
 dependencies[] = date_popup_authored
+dependencies[] = views_ui
 
 ; Panopoly Radix
-dependencies[] = radix_core
+dependencies[] = radix_layouts
+dependencies[] = radix_colorizer
 
 ; Panopoly Recommended - Other
 dependencies[] = devel
 dependencies[] = uuid
+dependencies[] = apps

--- a/SKELETON.info
+++ b/SKELETON.info
@@ -45,6 +45,9 @@ dependencies[] = save_draft
 dependencies[] = module_filter
 dependencies[] = date_popup_authored
 
+; Panopoly Radix
+dependencies[] = radix_core
+
 ; Panopoly Recommended - Other
 dependencies[] = devel
 dependencies[] = uuid

--- a/SKELETON.make
+++ b/SKELETON.make
@@ -13,41 +13,41 @@ projects[kw_itemnames][subdir] = "kraftwagen"
 
 ; The Panopoly Foundation
 
-projects[panopoly_core][version] = 1.1
+projects[panopoly_core][version] = 1.2
 projects[panopoly_core][subdir] = panopoly
 
-projects[panopoly_images][version] = 1.1
+projects[panopoly_images][version] = 1.2
 projects[panopoly_images][subdir] = panopoly
 
-projects[panopoly_theme][version] = 1.1
+projects[panopoly_theme][version] = 1.2
 projects[panopoly_theme][subdir] = panopoly
 
-projects[panopoly_magic][version] = 1.1
+projects[panopoly_magic][version] = 1.2
 projects[panopoly_magic][subdir] = panopoly
 
-projects[panopoly_widgets][version] = 1.1
+projects[panopoly_widgets][version] = 1.2
 projects[panopoly_widgets][subdir] = panopoly
 
-projects[panopoly_admin][version] = 1.1
+projects[panopoly_admin][version] = 1.2
 projects[panopoly_admin][subdir] = panopoly
 
-projects[panopoly_users][version] = 1.1
+projects[panopoly_users][version] = 1.2
 projects[panopoly_users][subdir] = panopoly
 
 ; The Panopoly Toolset
 
-projects[panopoly_pages][version] = 1.1
+projects[panopoly_pages][version] = 1.2
 projects[panopoly_pages][subdir] = panopoly
 
-projects[panopoly_wysiwyg][version] = 1.1
+projects[panopoly_wysiwyg][version] = 1.2
 projects[panopoly_wysiwyg][subdir] = panopoly
 
-projects[panopoly_search][version] = 1.1
+projects[panopoly_search][version] = 1.2
 projects[panopoly_search][subdir] = panopoly
 
 ; The Panopoly Radix
-projects[radix_core][subdir] = panopoly
-projects[radix_core][download][type] = git
-projects[radix_core][download][revision] = 472330c
-projects[radix_core][download][branch] = 7.x-1.x
-projects[radix_core][patch][] = https://drupal.org/files/issues/radix_core-update_radix_theme.patch
+projects[radix][version] = 3.0-alpha3
+projects[radix_colorizer][version] = 1.x-dev
+projects[radix_colorizer][subdir] = radix
+projects[radix_layouts][version] = 1.2
+projects[radix_layouts][subdir] = radix


### PR DESCRIPTION
This update also brings parts of Panopoly installation that were not ported yet.
We're defaulting to exclusive profile, since it's probably how it's meant to be used.
Also, some Radix modules are being brought in, previewing an inclusion expected for Panopoly 1.3
