### PR TITLE
Update version of Panopoly, Drupal core and Radix

### DIFF
--- a/SKELETON.make
+++ b/SKELETON.make
@@ -13,41 +13,41 @@ projects[kw_itemnames][subdir] = "kraftwagen"
 
 ; The Panopoly Foundation
 
-projects[panopoly_core][version] = 1.11
+projects[panopoly_core][version] = 1.21
 projects[panopoly_core][subdir] = panopoly
 
-projects[panopoly_images][version] = 1.11
+projects[panopoly_images][version] = 1.21
 projects[panopoly_images][subdir] = panopoly
 
-projects[panopoly_theme][version] = 1.11
+projects[panopoly_theme][version] = 1.21
 projects[panopoly_theme][subdir] = panopoly
 
-projects[panopoly_magic][version] = 1.11
+projects[panopoly_magic][version] = 1.21
 projects[panopoly_magic][subdir] = panopoly
 
-projects[panopoly_widgets][version] = 1.11
+projects[panopoly_widgets][version] = 1.21
 projects[panopoly_widgets][subdir] = panopoly
 
-projects[panopoly_admin][version] = 1.11
+projects[panopoly_admin][version] = 1.21
 projects[panopoly_admin][subdir] = panopoly
 
-projects[panopoly_users][version] = 1.11
+projects[panopoly_users][version] = 1.21
 projects[panopoly_users][subdir] = panopoly
 
 ; The Panopoly Toolset
 
-projects[panopoly_pages][version] = 1.11
+projects[panopoly_pages][version] = 1.21
 projects[panopoly_pages][subdir] = panopoly
 
-projects[panopoly_wysiwyg][version] = 1.11
+projects[panopoly_wysiwyg][version] = 1.21
 projects[panopoly_wysiwyg][subdir] = panopoly
 
-projects[panopoly_search][version] = 1.11
+projects[panopoly_search][version] = 1.21
 projects[panopoly_search][subdir] = panopoly
 
 ; For running the automated tests.
 
-projects[panopoly_test][version] = 1.11
+projects[panopoly_test][version] = 1.21
 projects[panopoly_test][subdir] = panopoly
 
 ; The Panopoly Radix

--- a/SKELETON.make
+++ b/SKELETON.make
@@ -51,12 +51,17 @@ projects[panopoly_test][version] = 1.21
 projects[panopoly_test][subdir] = panopoly
 
 ; The Panopoly Radix
-projects[radix][version] = 3.0-rc2
-projects[radix_layouts][version] = 3.3
-projects[radix_layouts][subdir] = radix
+;projects[radix_layouts][version] = 3.3
+;projects[radix_layouts][subdir] = radix
 ;projects[radix_admin][version] = 3.x-dev
 ;projects[radix_admin][subdir] = radix
 ;projects[radix_views][version] = 3.x-dev
 ;projects[radix_views][subdir] = radix
 ;projects[radix_colorizer][version] = 1.x-dev
 ;projects[radix_colorizer][subdir] = radix
+
+; Tallerini base theme
+projects[tallerini][type] = "theme"
+projects[tallerini][download][type] = "git"
+projects[tallerini][download][url] = "git://github.com/TallerWebSolutions/tallerini.git"
+projects[tallerini][subdir] = "kraftwagen"

--- a/SKELETON.make
+++ b/SKELETON.make
@@ -51,8 +51,8 @@ projects[panopoly_test][version] = 1.21
 projects[panopoly_test][subdir] = panopoly
 
 ; The Panopoly Radix
-projects[radix][version] = 3.0-beta1
-projects[radix_layouts][version] = 3.0-alpha2
+projects[radix][version] = 3.0-rc2
+projects[radix_layouts][version] = 3.3
 projects[radix_layouts][subdir] = radix
 ;projects[radix_admin][version] = 3.x-dev
 ;projects[radix_admin][subdir] = radix

--- a/tools/build.make.tpl
+++ b/tools/build.make.tpl
@@ -1,8 +1,11 @@
 core = 7.x
 api = 2
 
-projects[drupal][version] = "7.31"
+projects[drupal][version] = "7.36"
 
 projects[***MACHINE_NAME***][type] = "profile"
 projects[***MACHINE_NAME***][download][type] = "kraftwagen_directory"
 projects[***MACHINE_NAME***][download][url] = "**SRC_DIR**"
+
+; Bug with image styles on database update
+projects[drupal][patch][1973278] = http://www.drupal.org/files/issues/image-accommodate_missing_definition-1973278-16.patch


### PR DESCRIPTION
Simple version update.

Drupal Core: 7.36
Panopoly: 1.21
Radix: 3.0-rc2
Radix Layouts: 3.3

Cheers.
